### PR TITLE
add Ecpay response and client return url

### DIFF
--- a/app/assets/javascripts/thank.coffee
+++ b/app/assets/javascripts/thank.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/thank.scss
+++ b/app/assets/stylesheets/thank.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the thank controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,22 @@
+class ApiController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:feedback]
+
+  def feedback 
+    permitted = params.permit("CustomField1", "CustomField2", "CustomField3", "CustomField4", "MerchantID", "MerchantTradeNo", "PaymentDate", "PaymentType", "PaymentTypeChargeFee", "RtnCode", "RtnMsg", "SimulatePaid", "StoreID", "TradeAmt", "TradeDate", "TradeNo", "CheckMacValue" )
+    attributes = permitted.to_h || {}
+
+
+    check_mac_value = attributes["CheckMacValue"]
+    attributes.delete("CheckMacValue")
+    chk_value = attributes
+    real_mac_value = Ecpay::Invoice::CreateMacValue.new(attributes).run
+
+    if real_mac_value = check_mac_value
+      render plain: "1|OK", status: 200 
+    else
+      render plain: "NG", status: 400 
+    end
+  end
+end
+
+{"20190926WB4TFA7E" => 1}

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,14 +1,17 @@
 class OrdersController < ApplicationController
   before_action :find_order
 
+  def index
+  end
+
   def show
     #以下金流部分
     @merchan_trade_no = order_generator
     @time = time_generator
     @total_amount = @order.total_price
     @item_name = @order.item_name
-    @return_url = 'http://da202e30.ngrok.io/api/feedback'
-
+    @return_url = "http://da202e30.ngrok.io/api/feedback"
+    @client_back_url = "http://da202e30.ngrok.io/thank"
 
     @check_mac_value = Ecpay::Invoice::CreateMacValue.new(raw_params).run
   end
@@ -42,7 +45,8 @@ class OrdersController < ApplicationController
     'ItemName' => @item_name,
     'ReturnURL' => @return_url ,
     'ChoosePayment' => 'Credit',
-    'EncryptType' => 1
+    'EncryptType' => 1,
+    'ClientBackURL' => @client_back_url
   }
   end
 end

--- a/app/controllers/thank_controller.rb
+++ b/app/controllers/thank_controller.rb
@@ -1,0 +1,4 @@
+class ThankController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/thank_helper.rb
+++ b/app/helpers/thank_helper.rb
@@ -1,0 +1,2 @@
+module ThankHelper
+end

--- a/app/service/ecpay/invoice/create_mac_value.rb
+++ b/app/service/ecpay/invoice/create_mac_value.rb
@@ -2,21 +2,21 @@ module Ecpay
   module Invoice
     class CreateMacValue
 
-      def initialize(params = {})
-        @params = params
+      def initialize(inside_params = {})
+        @inside_params = inside_params
       end
 
       def run
-        compute_check_mac_value(@params)
+        compute_check_mac_value(@inside_params)
       end
 
       private
-      def compute_check_mac_value(params)
+      def compute_check_mac_value(hash)
         # 先將參數備份
-        params = params.dup
+        hash = hash.dup
 
         # 轉成 query_string
-        query_string = to_query_string(params)
+        query_string = to_query_string(hash)
         # 加上 HashKey 和 HashIV
         query_string = "HashKey=5294y06JbISpM5x9&#{query_string}&HashIV=v77hoKGq4kWxNNIS"
         # 進行 url encode
@@ -40,17 +40,17 @@ module Ecpay
         encoded_data
       end
 
-      def to_query_string(params)
+      def to_query_string(hash)
         # 對小寫的 key 排序
-        params = params.sort_by do |key, _val|
+        hash = hash.sort_by do |key, _val|
           key.downcase
         end
 
         # 組成 query_string
-        params = params.map do |key, val|
+        hash = hash.map do |key, val|
           "#{key}=#{val}"
         end
-        params.join('&')
+        hash.join('&')
       end
 
     end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -9,6 +9,7 @@
   <%= f.hidden_field :ReturnURL, value: @return_url  %>
   <%= f.hidden_field :ChoosePayment, value: 'Credit' %>
   <%= f.hidden_field :EncryptType, value: "1" %>
+  <%= f.hidden_field :ClientBackURL, value: @client_back_url %>
   <%= f.hidden_field :CheckMacValue, value: @check_mac_value %>
 
 <% end %>

--- a/app/views/thank/index.html.erb
+++ b/app/views/thank/index.html.erb
@@ -1,0 +1,3 @@
+<h1>感謝使用 GoodBuy 您將在交易成功後收到郵件通知</h1>
+
+<%= link_to "回到首頁", my_groups_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   end
 
   resources :orders, only: [:show]
+  resources :thank, only: [:index]
+  post "api/feedback" ,to: "api#feedback"
 
 
 

--- a/test/controllers/thank_controller_test.rb
+++ b/test/controllers/thank_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ThankControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
1. 功能：接收綠界回復的 post 訊息，檢查過後正常回傳 OK，否則ＮＧ
2. 新增綠界付款完成後可以回到謝謝使用的頁面 (網址要改成部署的網址)