### PR TITLE
fix issue of create mac value hash translate to string issue

### DIFF
--- a/app/service/ecpay/invoice/create_mac_value.rb
+++ b/app/service/ecpay/invoice/create_mac_value.rb
@@ -47,10 +47,7 @@ module Ecpay
         end
 
         # 組成 query_string
-        hash = hash.map do |key, val|
-          "#{key}=#{val}"
-        end
-        hash.join('&')
+        hash.to_query
       end
 
     end


### PR DESCRIPTION
fix issue of hash to string translate issue
```
# example
{a: 1, b:2, c: "3&a=5&b=6"}
```